### PR TITLE
#5 - 🍃 클래스 분리하기(Builder)

### DIFF
--- a/hodolog/src/main/java/com/hodolog/hodolog/controller/ExceptionController.java
+++ b/hodolog/src/main/java/com/hodolog/hodolog/controller/ExceptionController.java
@@ -12,12 +12,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Log4j2
 @RestControllerAdvice
 public class ExceptionController {
-    // 지난 시간에는 JSON 형식으로 받은 데이터를 @NotBlank 으로 검사를 하고 ExceptionHandler 를 통해서 적절한 에러 메시지를 작성했다.
 
+    // 잘못된 요청이 올 때 수행.
+    // MethodArgumentNotValidException 은 BindException 이 발생했을 때 좀 더 자세한 내용을 설명하기 위해 스프링 3.1부터 개편
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ErrorResponse invalidRequestHandler(MethodArgumentNotValidException e) {
-        ErrorResponse response = new ErrorResponse("400", "잘못된 요청입니다.");
+        ErrorResponse response = ErrorResponse.builder()
+                .code("400")
+                .message("잘못된 요청입니다.")
+                .build();
 
         for(FieldError fieldError: e.getFieldErrors()) {
             response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());

--- a/hodolog/src/main/java/com/hodolog/hodolog/controller/PostController.java
+++ b/hodolog/src/main/java/com/hodolog/hodolog/controller/PostController.java
@@ -1,6 +1,5 @@
 package com.hodolog.hodolog.controller;
 
-import com.hodolog.hodolog.repositroy.PostRepository;
 import com.hodolog.hodolog.request.PostCreate;
 import com.hodolog.hodolog.service.PostService;
 import jakarta.validation.Valid;
@@ -10,18 +9,24 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 @Log4j2
 @RequiredArgsConstructor
 @RestController
 public class PostController {
-    
+
     private final PostService postService;
 
+    // Method POST 수행 이후에 응답을 안하는 경우가 많다. POST: 200, 201 위주
     @PostMapping("/posts")
-    public Map<String, String> post(@RequestBody @Valid PostCreate request)  {
+    public void post(@RequestBody @Valid PostCreate request) {
+        // Case 1. 저장한 데이터 Entity -> response 으로 응답하기
+        // Case 2. 저장한 데이터의 primary_id -> response 으로 응답하기:
+        //         클라이언트는 수신한 primary_id 를 글 조회 API 를 통해서 데이터를 수신받음
+        // Case 3. 저장한 데이터 응답 안하기:
+        //         클라이언트에서 모든 POST(글) 데이터 context 를 잘 관리함
+        // Bad Case: 서버에서 반드시 이렇게 할껍니다! fix -> X
+        //           서버에서 차라리 유연하게 대응하는게 좋습니다. -> 코드를 잘 짜야겠죠?! ㅎ
+        //           한 번에 일괄적으로 잘 처리되는 케이스는 없습니다. -> 잘 관리하는 형태가 중요합니다.
         postService.write(request);
-        return Map.of();
     }
 }

--- a/hodolog/src/main/java/com/hodolog/hodolog/domain/Post.java
+++ b/hodolog/src/main/java/com/hodolog/hodolog/domain/Post.java
@@ -2,6 +2,7 @@ package com.hodolog.hodolog.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +18,7 @@ public class Post {
     @Lob
     private String content;
 
+    @Builder
     public Post(String title, String content) {
         this.title = title;
         this.content = content;

--- a/hodolog/src/main/java/com/hodolog/hodolog/request/PostCreate.java
+++ b/hodolog/src/main/java/com/hodolog/hodolog/request/PostCreate.java
@@ -1,6 +1,7 @@
 package com.hodolog.hodolog.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -11,8 +12,27 @@ import lombok.ToString;
 public class PostCreate {
 
     @NotBlank(message = "타이틀을 입력해주세요.")
-    private String title;
+    private final String title;
 
     @NotBlank(message = "콘텐츠를 입력해주세요.")
-    private String content;
+    private final String content;
+
+    @Builder // 개인적으로 생성자에 붙이기: 클래스에 붙이게되면 필드가 final 인지 아닌지에 따라 빌더 클래스 모순이 발생할 가능성이 존재한다.
+    public PostCreate(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    /**
+     * 빌더의 장점: 객체의 불변성, 가독성, 객체 생성 유연함, 필요한 값만 할당이 가능
+     * 생성자 방식 -> 코드 늘어나고, 오버로딩이 수행되어야 한다.
+     * 오버로딩이 가능한 조건과 관련이 있다.
+     */
+    // private final 까지 선호하는 편. final 적용된 필드는 새로 객체를 복사해서 새로 생성해야 한다.
+//    public PostCreate changeTitle(String title) {
+//        return PostCreate.builder()
+//                .content(content)
+//                .title(title)
+//                .build();
+//    }
 }

--- a/hodolog/src/main/java/com/hodolog/hodolog/response/ErrorResponse.java
+++ b/hodolog/src/main/java/com/hodolog/hodolog/response/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.hodolog.hodolog.response;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -15,11 +16,17 @@ import java.util.Map;
  */
 
 @Getter
-@RequiredArgsConstructor
 public class ErrorResponse {
+
     private final String code;
     private final String message;
     private final Map<String, String> validation = new HashMap<>();
+
+    @Builder
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
 
     public void addValidation(String fieldName, String errorMessage) {
         this.validation.put(fieldName, errorMessage);

--- a/hodolog/src/main/java/com/hodolog/hodolog/service/PostService.java
+++ b/hodolog/src/main/java/com/hodolog/hodolog/service/PostService.java
@@ -16,7 +16,11 @@ public class PostService {
 
     public void write(PostCreate postCreate) {
         // postCreate -> Entity
-        Post post = new Post(postCreate.getContent(), postCreate.getTitle());
+        Post post = Post.builder()
+                .title(postCreate.getTitle())
+                .content(postCreate.getContent())
+                .build();
+
         postRepository.save(post);
     }
 }

--- a/hodolog/src/test/java/com/hodolog/hodolog/controller/PostControllerTest.java
+++ b/hodolog/src/test/java/com/hodolog/hodolog/controller/PostControllerTest.java
@@ -1,6 +1,8 @@
 package com.hodolog.hodolog.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hodolog.hodolog.repositroy.PostRepository;
+import com.hodolog.hodolog.request.PostCreate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -8,15 +10,19 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @AutoConfigureMockMvc
 @SpringBootTest
 class PostControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private MockMvc mockMvc;
@@ -32,41 +38,67 @@ class PostControllerTest {
     @Test
     @DisplayName("/posts 요청 시 Hello World 를 출력한다.")
     void GivenPosts() throws Exception {
+        // Given
+        PostCreate request = PostCreate.builder()
+                .title("제목입니다.")
+                .content("내용입니다.")
+                .build();
+
+        String json = objectMapper.writeValueAsString(request);// 자바 빈 규약을 따라서 변경 객체 -> JSON 포멧으로 변경한다.
+
+        System.out.println("json = " + json);
+
         // expected
-        mockMvc.perform(MockMvcRequestBuilders.post("/posts")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\": \"제목입니다.\", \"content\": \"내용입니다.\"}")
+        mockMvc.perform(post("/posts")
+                        .contentType(APPLICATION_JSON)
+                        .content(json)
                 )
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().string("{}"))
-                .andDo(MockMvcResultHandlers.print());
+                .andExpect(status().isOk())
+                .andExpect(content().string("{}"))
+                .andDo(print());
     }
 
     @Test
     @DisplayName("/posts 요청 시 title 값은 필수이다.")
     void GivenTitle() throws Exception {
+        // Given
+        PostCreate request = PostCreate.builder()
+//                .title("제목입니다.")  // title 을 넘기지 않는다.
+                .content("내용입니다.")
+                .build();
+
+        String json = objectMapper.writeValueAsString(request);// 자바 빈 규약을 따라서 변경 객체 -> JSON 포멧으로 변경한다.
+
         // expected
-        mockMvc.perform(MockMvcRequestBuilders.post("/posts")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\": null, \"content\": \"내용입니다.\"}")
+        mockMvc.perform(post("/posts")
+                        .contentType(APPLICATION_JSON)
+                        .content(json)
                 )
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("400"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("잘못된 요청입니다."))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.validation.title").value("타이틀을 입력해주세요."))
-                .andDo(MockMvcResultHandlers.print());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.validation.title").value("타이틀을 입력해주세요."))
+                .andDo(print());
     }
 
     @Test
     @DisplayName("/posts 요청 시 DB 에 POST 값이 저장된다.")
     void GivenPost() throws Exception {
+        // Given
+        PostCreate request = PostCreate.builder()
+                .title("제목입니다.")
+                .content("내용입니다.")
+                .build();
+
+        String json = objectMapper.writeValueAsString(request);// 자바 빈 규약을 따라서 변경 객체 -> JSON 포멧으로 변경한다.
+
         // when
-        mockMvc.perform(MockMvcRequestBuilders.post("/posts")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\": \"제목입니다.\", \"content\": \"내용입니다.\"}")
+        mockMvc.perform(post("/posts")
+                        .contentType(APPLICATION_JSON)
+                        .content(json)
                 )
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andDo(MockMvcResultHandlers.print());
+                .andExpect(status().isOk())
+                .andDo(print());
 
         // then
         Assertions.assertEquals(1L, postRepository.count());


### PR DESCRIPTION
**ExceptionController 클래스는 컨트롤러 작성된 @Valid 에 의해 잘못된 요청이 온다면 수행된다.**
- ethodArgumentNotValidException 은 **BindException** 이 발생했을 때 좀 더 자세한 내용을 설명하기 위해 스프링 3.1부터 개편

     **Method POST 수행 이후에 응답을 안하는 경우가 많다. POST: 200, 201 위주**
         Case 1. 저장한 데이터 Entity -> response 으로 응답하기
         Case 2. 저장한 데이터의 primary_id -> response 으로 응답하기:
                 클라이언트는 수신한 primary_id 를 글 조회 API 를 통해서 데이터를 수신받음
         Case 3. 저장한 데이터 응답 안하기:
                 클라이언트에서 모든 POST(글) 데이터 context 를 잘 관리함
         Bad Case: 서버에서 반드시 이렇게 할껍니다! fix -> X
                   서버에서 차라리 유연하게 대응하는게 좋습니다. -> 코드를 잘 짜야겠죠?! ㅎ
                  한 번에 일괄적으로 잘 처리되는 케이스는 없습니다. -> 잘 관리하는 형태가 중요합니다.

**Builder**
-  개인적으로 생성자에 붙이기: 클래스에 붙이게되면 필드가 final 인지 아닌지에 따라 빌더 클래스 모순이 발생할 가능성이 존재한다.

    
     * **빌더의 장점**: 객체의 불변성, 가독성, 객체 생성 유연함, 필요한 값만 할당이 가능
     * **생성자 방식** -> 코드 늘어나고, 오버로딩이 수행되어야 한다. * 오버로딩이 가능한 조건과 관련이 있다. 
     * **private final** 까지 선호하는 편. final 적용된 필드는 새로 객체를 복사해서 새로 생성해야 한다.

```java
    public PostCreate changeTitle(String title) {
        return PostCreate.builder()
                .content(content)
                .title(title)
                .build();
    }
}
```

**objectMapper**
- 자바 빈 규약을 따라서 객체를 JSON 포멧으로 변경한다.